### PR TITLE
throw an error when incorrect semver-update-type is specified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ async function modifyUnityProjSemVer() {
                         semverAsObj.patch = 0;
                         break;
                     default:
+                        core.setFailed("major, minor or patch must be specified as semver-update-type.");
                         break;
                 }
 


### PR DESCRIPTION
Throws an error when **major**, **minor** or **patch**  is not specified as the `semver-update-type`.

See https://github.com/AlexHolderDeveloper/UnityAutomatedSemver/issues/1