### PR TITLE
Add the ability to specify the exact project-settings-path instead of automatically searching for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ When calling this action, you can specify the type of semver update you'd like t
 * minor - This increments the second number in a "major.minor.patch" version string
 * patch - This increments the third number in a "major.minor.patch" version string
 
+### project-settings-path (optional)
+
+The path to the ProjectSettings/ProjectSettings.asset file for your unity project. If not specified will attempt to automatically find it.
+
 ## Outputs 
 
 This is the data that you can use after this action has completed, in other actions & scripts.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When calling this action, you can specify the type of semver update you'd like t
 
 ### project-settings-path (optional)
 
-The path to the ProjectSettings/ProjectSettings.asset file for your unity project. If not specified will attempt to automatically find it.
+The path to the ProjectSettings/ProjectSettings.asset file for your unity project. If not specified will action will attempt to automatically find it.
 
 ## Outputs 
 
@@ -55,7 +55,8 @@ jobs:
         id: semver-update
         with:
           semver-update-type: 'patch' # Change this string to any suitable string mentioned in the Inputs section of this action's readme to suit your needs.
-      
+          project-settings-path: 'ProjectSettings/ProjectSettings.asset' # optional: specify the exact location of the ProjectSettings file, otherwise action will attempt to automatically find it.
+
       # Validate that the number has been incremented correctly.
       - name: Get the new semver number
         run: echo "The new semver number for this Unity project is ${{ steps.semver-update.outputs.semver-number }}"

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Which number to increment based on semver rules.'
     required: true
     default: 'patch'
+  project-settings-path: # example ProjectSettings/ProjectSettings.asset
+    description: 'Path to the ProjectSettings.asset file'
+    required: false
 outputs:
   semver-number: # id of output
     description: 'The new semver number of this Unity project.'

--- a/src/index.js
+++ b/src/index.js
@@ -87,8 +87,9 @@ async function modifyUnityProjSemVer() {
             console.log(`Semver is now: ${JSON.stringify(semverAsObj)}`);
 
             // 8. Convert semver obj back into string
-            let newSemverAsString = `bundleVersion: ${semverAsObj.major}.${semverAsObj.minor}.${semverAsObj.patch}`;
-            core.setOutput("semver-number", newSemverAsString)
+            let newSemver = `${semverAsObj.major}.${semverAsObj.minor}.${semverAsObj.patch}`;
+            core.setOutput("semver-number", newSemver);
+            let newSemverAsString = `bundleVersion: ` + newSemver;
 
             // 9. Insert string back into ProjectSettings.asset file
             fs.readFile(projectSettingsFilePath, "utf8", (error, data) => {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ async function modifyUnityProjSemVer() {
     let projectSettingsFilePath = "";
     if(core.getInput("project-settings-path")){
         console.log("project-settings-path input detected...")
-        projectSettingsFilePath = process.env.GITHUB_WORKSPACE + core.getInput("project-settings-path");
+        projectSettingsFilePath = process.env.GITHUB_WORKSPACE + "/" + core.getInput("project-settings-path");
     }else{
         console.log("ProjectSettingsPath input NOT detected...attempting to automatically find ProjectSettings/ProjectSettings.asset")
         projectSettingsFilePath = findProjectSettingsPath();

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ async function modifyUnityProjSemVer() {
     let projectSettingsFilePath = "";
     if(core.getInput("project-settings-path")){
         console.log("project-settings-path input detected...")
-        projectSettingsFilePath = core.getInput("ProjectSettingsPath");
+        projectSettingsFilePath = process.env.GITHUB_WORKSPACE + core.getInput("project-settings-path");
     }else{
         console.log("ProjectSettingsPath input NOT detected...attempting to automatically find ProjectSettings/ProjectSettings.asset")
         projectSettingsFilePath = findProjectSettingsPath();

--- a/src/index.js
+++ b/src/index.js
@@ -4,115 +4,116 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 const find = require('find');
 
-
-async function modifyUnityProjSemVer() {
-    // 1. find ProjectSettings.asset
-    var foundFileNames = [];
-    // console.log(github.context);
-    console.log("env.GITHUB_WORKSPACE points to this value: " + process.env.GITHUB_WORKSPACE);
+/**
+ * Find and returns the first path that contains a ProjectSettings.asset file
+ * @returns string the path to the unity ProjectSettings/ProjectSettings.asset file ... hopefully
+ */
+function findProjectSettingsPath(){
+    let foundFileNames = [];
     find.file(/\b(ProjectSettings.asset)\b/, process.env.GITHUB_WORKSPACE, (files) => {
         foundFileNames = files;
         console.log(`We found these relevant files: \n ${foundFileNames}`);
-
-
-        var projectSettingsFilePath = foundFileNames[0];
-        console.log("Path to ProjectSettings.asset using env.GITHUB_WORKSPACE: ---------\n" + projectSettingsFilePath + "\n---------------")
-        // 2. make a copy of that file 
-        var copiedFileContents = '';
-
-        fs.copyFile(projectSettingsFilePath, "tempfile.yaml", (error) => {
-            if (error) {
-                console.log(`Error found:\n${error}`);
-            } else {
-                console.log("Successfully copied file! Reading it back in now...")
-                copiedFileContents = fs.readFileSync("tempfile.yaml", "utf8");
-                copiedFileAsArray = copiedFileContents.split('\n');
-
-                // 3. strip the first 4 lines from the copy
-                copiedFileAsArray.splice(0, 3);
-                copiedFileContents = copiedFileAsArray.join('\n')
-                fs.unlinkSync('tempfile.yaml');
-
-                // 4. parse the modified copy as yaml
-                // 5. convert that yaml to json
-                const doc = yaml.safeLoad(copiedFileContents, json = true);
-                console.log("----------")
-                console.log("Verifying that existing data can be read: " + doc.PlayerSettings.bundleVersion)
-                var semverAsObj = {
-                    major: 0,
-                    minor: 0,
-                    patch: 0
-                }
-                bundleVersionAsArray = doc.PlayerSettings.bundleVersion.split(".");
-                semverAsObj.major = parseInt(bundleVersionAsArray[0]);
-                semverAsObj.minor = parseInt(bundleVersionAsArray[1]);
-                semverAsObj.patch = parseInt(bundleVersionAsArray[2]);
-
-
-                // 6. Get commit tag
-                var commitTag = core.getInput('semver-update-type').toLowerCase();
-                console.log("core.getInput('semver-update-type').toLowerCase() ----------------->" + commitTag)
-
-                // 7. Increment specific number based on commit tag
-                switch (commitTag) {
-                    case "patch":
-                        console.log("yep, was a patch!");
-                        semverAsObj.patch++;
-                        break;
-                    case "minor":
-                        console.log("we did a minor tag commit!");
-                        semverAsObj.minor++;
-                        semverAsObj.patch = 0;
-                        break;
-                    case "major":
-                        console.log("MAJOR patch omg!");
-                        semverAsObj.major++;
-                        semverAsObj.minor = 0;
-                        semverAsObj.patch = 0;
-                        break;
-                    default:
-                        core.setFailed("major, minor or patch must be specified as semver-update-type.");
-                        break;
-                }
-
-                console.log(`Semver is now: ${JSON.stringify(semverAsObj)}`);
-
-                // 8. Convert semver obj back into string
-                let newSemverAsString = `bundleVersion: ${semverAsObj.major}.${semverAsObj.minor}.${semverAsObj.patch}`;
-                core.setOutput("semver-number", newSemverAsString)
-
-                // 9. Insert string back into ProjectSettings.asset file
-                fs.readFile(projectSettingsFilePath, "utf8", (error, data) => {
-                    if (error){
-                        return console.log(`Something went wrong reading the original ProjectSetting.asset! Error message follows: \n${error}`);
-                    }
-
-                    var result = data.replace(/\b(bundleVersion\: )(([0-9]+).([0-9]+).([0-9]+))\b/, newSemverAsString);
-                    fs.writeFile(projectSettingsFilePath, result, 'utf8', (error) => {
-                        if (error){
-                            return console.log(`Something went wrong inserting the new semver into the original ProjectSetting.asset! Error message follows: \n${error}`);
-                        }
-                    })
-
-                })
-
-                // 10. Commit & push changes back to the repo
-
-
-            }
-        })
-
-
-
-
-
-
+        return foundFileNames[0];
     }).error(error => {
         console.log("Something went wrong finding the file. Please try something else.")
         console.log("find.file error message is: \n" + error);
     })
+    return "";
+}
+
+async function modifyUnityProjSemVer() {
+    // 1. find ProjectSettings.asset
+    console.log("env.GITHUB_WORKSPACE points to this value: " + process.env.GITHUB_WORKSPACE);
+    let projectSettingsFilePath = "";
+    if(core.getInput("project-settings-path")){
+        console.log("project-settings-path input detected...")
+        projectSettingsFilePath = core.getInput("ProjectSettingsPath");
+    }else{
+        console.log("ProjectSettingsPath input NOT detected...attempting to automatically find ProjectSettings/ProjectSettings.asset")
+        projectSettingsFilePath = findProjectSettingsPath();
+    }
+    console.log("Path to ProjectSettings.asset using env.GITHUB_WORKSPACE: ---------\n" + projectSettingsFilePath + "\n---------------")
+    // 2. make a copy of that file
+    let copiedFileContents = '';
+
+    fs.copyFile(projectSettingsFilePath, "tempfile.yaml", (error) => {
+        if (error) {
+            console.log(`Error found:\n${error}`);
+        } else {
+            console.log("Successfully copied file! Reading it back in now...")
+            copiedFileContents = fs.readFileSync("tempfile.yaml", "utf8");
+            copiedFileAsArray = copiedFileContents.split('\n');
+
+            // 3. strip the first 4 lines from the copy
+            copiedFileAsArray.splice(0, 3);
+            copiedFileContents = copiedFileAsArray.join('\n')
+            fs.unlinkSync('tempfile.yaml');
+
+            // 4. parse the modified copy as yaml
+            // 5. convert that yaml to json
+            const doc = yaml.safeLoad(copiedFileContents, json = true);
+            console.log("----------")
+            console.log("Verifying that existing data can be read: " + doc.PlayerSettings.bundleVersion)
+            var semverAsObj = {
+                major: 0,
+                minor: 0,
+                patch: 0
+            }
+            bundleVersionAsArray = doc.PlayerSettings.bundleVersion.split(".");
+            semverAsObj.major = parseInt(bundleVersionAsArray[0]);
+            semverAsObj.minor = parseInt(bundleVersionAsArray[1]);
+            semverAsObj.patch = parseInt(bundleVersionAsArray[2]);
 
 
+            // 6. Get commit tag
+            var commitTag = core.getInput('semver-update-type').toLowerCase();
+            console.log("core.getInput('semver-update-type').toLowerCase() ----------------->" + commitTag)
+
+            // 7. Increment specific number based on commit tag
+            switch (commitTag) {
+                case "patch":
+                    console.log("yep, was a patch!");
+                    semverAsObj.patch++;
+                    break;
+                case "minor":
+                    console.log("we did a minor tag commit!");
+                    semverAsObj.minor++;
+                    semverAsObj.patch = 0;
+                    break;
+                case "major":
+                    console.log("MAJOR patch omg!");
+                    semverAsObj.major++;
+                    semverAsObj.minor = 0;
+                    semverAsObj.patch = 0;
+                    break;
+                default:
+                    core.setFailed("major, minor or patch must be specified as semver-update-type.");
+                    break;
+            }
+
+            console.log(`Semver is now: ${JSON.stringify(semverAsObj)}`);
+
+            // 8. Convert semver obj back into string
+            let newSemverAsString = `bundleVersion: ${semverAsObj.major}.${semverAsObj.minor}.${semverAsObj.patch}`;
+            core.setOutput("semver-number", newSemverAsString)
+
+            // 9. Insert string back into ProjectSettings.asset file
+            fs.readFile(projectSettingsFilePath, "utf8", (error, data) => {
+                if (error){
+                    return console.log(`Something went wrong reading the original ProjectSetting.asset! Error message follows: \n${error}`);
+                }
+
+                var result = data.replace(/\b(bundleVersion\: )(([0-9]+).([0-9]+).([0-9]+))\b/, newSemverAsString);
+                fs.writeFile(projectSettingsFilePath, result, 'utf8', (error) => {
+                    if (error){
+                        return console.log(`Something went wrong inserting the new semver into the original ProjectSetting.asset! Error message follows: \n${error}`);
+                    }
+                })
+
+            })
+
+        }
+    })
 }
 
 modifyUnityProjSemVer();

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,9 @@ const find = require('find');
  * @returns string the path to the unity ProjectSettings/ProjectSettings.asset file ... hopefully
  */
 function findProjectSettingsPath(){
-    let foundFileNames = [];
-    find.file(/\b(ProjectSettings.asset)\b/, process.env.GITHUB_WORKSPACE, (files) => {
-        foundFileNames = files;
-        console.log(`We found these relevant files: \n ${foundFileNames}`);
-        return foundFileNames[0];
-    }).error(error => {
-        console.log("Something went wrong finding the file. Please try something else.")
-        console.log("find.file error message is: \n" + error);
-    })
-    return "";
+    let foundFileNames = find.fileSync(/\b(ProjectSettings.asset)\b/, process.env.GITHUB_WORKSPACE);
+    console.log(`We found these relevant files: \n ${foundFileNames}`);
+    return foundFileNames[0];
 }
 
 async function modifyUnityProjSemVer() {

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ async function modifyUnityProjSemVer() {
                         semverAsObj.patch = 0;
                         break;
                     default:
+                        core.setFailed("major, minor or patch must be specified as semver-update-type.");
                         break;
                 }
 


### PR DESCRIPTION
With the old implementation, the action would attempt to find the ProjectSettings.asset path automatically. In my case this caused the action to not work because it would resolve to the wrong file (it turns out [Ludiq](https://ludiq.io/) names some of it's asset files `ProjectSettings.asset` as well).

In an attempt to fix this behavior I have added `project-settings-path` as an input to allow users to specify the exact location of the `ProjectSettings.asset` file. If the input is specified it will resolve to that exact location for semver updating, otherwise, it will attempt to automatically find the file as was previously occurring.

See image below for issue

![image](https://user-images.githubusercontent.com/2967721/145050902-9b83d599-afa3-4618-973b-92732e60744c.png)
